### PR TITLE
library: Replace Pixbufs with Textures in HTTP Image demo

### DIFF
--- a/src/Library/demos/HTTP Image/main.js
+++ b/src/Library/demos/HTTP Image/main.js
@@ -1,34 +1,31 @@
 import GLib from "gi://GLib";
 import Gdk from "gi://Gdk";
-import GdkPixbuf from "gi://GdkPixbuf";
 import Gio from "gi://Gio";
 import Soup from "gi://Soup";
 
 // https://picsum.photos/
 const IMAGE_URL = "https://picsum.photos/800";
 
-Gio._promisify(Soup.Session.prototype, "send_async", "send_finish");
 Gio._promisify(
-  GdkPixbuf.Pixbuf,
-  "new_from_stream_async",
-  "new_from_stream_finish",
+  Soup.Session.prototype,
+  "send_and_read_async",
+  "send_and_read_finish",
 );
 
-const input_stream = await getInputStream(IMAGE_URL);
-const pixbuf = await GdkPixbuf.Pixbuf.new_from_stream_async(input_stream, null);
-const texture = Gdk.Texture.new_for_pixbuf(pixbuf);
+const image_bytes = await getImageBytes(IMAGE_URL);
+const texture = Gdk.Texture.new_from_bytes(image_bytes);
 workbench.builder.get_object("picture").set_paintable(texture);
 
-async function getInputStream(url) {
+async function getImageBytes(url) {
   const session = new Soup.Session();
   const message = new Soup.Message({
     method: "GET",
     uri: GLib.Uri.parse(url, GLib.UriFlags.NONE),
   });
-  const input_stream = await session.send_async(message, null, null);
+  const bytes = await session.send_and_read_async(message, null, null);
   const { status_code, reason_phrase } = message;
   if (status_code !== 200) {
     throw new Error(`Got ${status_code}, ${reason_phrase}`);
   }
-  return input_stream;
+  return bytes;
 }


### PR DESCRIPTION
Since GTK4, the `GdkPixbuf` APIs [have been de-emphasized,](https://docs.gtk.org/gtk4/migrating-3to4.html#gdkpixbuf-is-deemphasized) and `Gdk.Paintable`/`Gdk.Texture` are the recommended replacements. This PR removes the usage of Pixbuf-related APIs in favour of `Gdk.Texture`.

I will make the changes to the existing ports of this demo in separate PRs.