### PR TITLE
library: Remove `Gdk.Pixbuf`-related APIs in HTTP Image Vala demo

### DIFF
--- a/src/Library/demos/HTTP Image/main.vala
+++ b/src/Library/demos/HTTP Image/main.vala
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S vala workbench.vala --pkg libadwaita-1 --pkg gdk-pixbuf-2.0 --pkg libsoup-3.0
+#!/usr/bin/env -S vala workbench.vala --pkg libadwaita-1 --pkg libsoup-3.0
 
 public errordomain MessageError {
   FAILED;
@@ -9,21 +9,19 @@ private const string IMAGE_URL = "https://picsum.photos/800";
 
 public async void main () {
   try {
-    var input_stream = yield get_input_stream (IMAGE_URL);
-    var pixbuf = yield new Gdk.Pixbuf.from_stream_async (input_stream, null);
-    var texture = Gdk.Texture.for_pixbuf(pixbuf);
     var picture = (Gtk.Picture) workbench.builder.get_object ("picture");
-    picture.set_paintable (texture);
+    Bytes image_bytes = yield get_image_bytes (IMAGE_URL);
+    picture.paintable = Gdk.Texture.from_bytes (image_bytes);
   } catch (Error e) {
     critical (e.message);
   }
 }
 
-private async InputStream? get_input_stream (string url) throws Error {
+private async Bytes? get_image_bytes (string url) throws Error {
   var session = new Soup.Session ();
   var message = new Soup.Message.from_uri ("GET", Uri.parse (url, NONE));
 
-  InputStream input_stream = yield session.send_async (message, Priority.DEFAULT, null);
+  Bytes image_bytes = yield session.send_and_read_async (message, Priority.DEFAULT, null);
 
   uint status_code = message.status_code;
   string reason = message.reason_phrase;
@@ -32,5 +30,5 @@ private async InputStream? get_input_stream (string url) throws Error {
     throw new MessageError.FAILED (@"Got $status_code: $reason");
   }
 
-  return input_stream;
+  return image_bytes;
 }


### PR DESCRIPTION
Related to #796 

Replaces the uses of `Gdk.Pixbuf`-related APIs in favour of `Gdk.Texture`, as Pixbufs have been de-emphasized in GTK4.