### PR TITLE
library: Remove Gdk.Pixbuf-related APIs in HTTP Image Rust demo

### DIFF
--- a/src/Library/demos/HTTP Image/code.rs
+++ b/src/Library/demos/HTTP Image/code.rs
@@ -2,10 +2,8 @@
 // For real applications, you probably want to use a different HTTP library in Rust
 
 use crate::workbench;
-use gdk_pixbuf::Pixbuf;
-use gio::InputStream;
 use glib::source::Priority;
-use gtk::{gdk, gdk_pixbuf, gio, glib};
+use gtk::{gdk, glib};
 use soup::prelude::*;
 
 pub fn main() {
@@ -15,18 +13,17 @@ pub fn main() {
 async fn async_main() {
     // https://picsum.photos/
     let image_url = "https://picsum.photos/800";
-    let input_stream = get_input_stream(image_url).await;
-    let pixbuf = Pixbuf::from_stream_future(&input_stream).await.unwrap();
-    let texture = gdk::Texture::for_pixbuf(&pixbuf);
+    let image_bytes = get_image_bytes(image_url).await;
+    let texture = gdk::Texture::from_bytes(&image_bytes).unwrap();
     let picture: gtk::Picture = workbench::builder().object("picture").unwrap();
     picture.set_paintable(Some(&texture));
 }
 
-async fn get_input_stream(url: &str) -> InputStream {
+async fn get_image_bytes(url: &str) -> glib::Bytes {
     let session = soup::Session::new();
     let message = soup::Message::new("GET", url).unwrap();
-    let input_stream = session
-        .send_future(&message, Priority::DEFAULT)
+    let image_bytes = session
+        .send_and_read_future(&message, Priority::DEFAULT)
         .await
         .unwrap();
 
@@ -37,5 +34,5 @@ async fn get_input_stream(url: &str) -> InputStream {
             message.reason_phrase()
         );
     }
-    input_stream
+    image_bytes
 }


### PR DESCRIPTION
Related to #796

Replaces the uses of `Gdk.Pixbuf`-related APIs in favour of `Gdk.Texture`, as Pixbufs have been de-emphasized in GTK4.