### PR TITLE
python: fix Previewer not being closable

### DIFF
--- a/src/langs/python/python-previewer.py
+++ b/src/langs/python/python-previewer.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 """
 This is the previewer for Python demos. It connects via DBus back to
-Workbench and loads demos.
-
-This module also provides itself to demos via importing "workbench"
-with the fields defined in __all__.
+Workbench and loads demos, providing them with a "workbench" module for
+the Workbench API.
 """
 from __future__ import annotations
 
@@ -89,6 +87,7 @@ class Previewer:
         # Set target as window directly
         if self.window is None or self.window.__class__ != self.target.__class__:
             self.set_window(cast(Gtk.Window, self.target))
+            return
 
         if isinstance(self.target, Adw.Window) or isinstance(
             self.target, Adw.ApplicationWindow


### PR DESCRIPTION
This fixes #745.

Forgot a pretty critical "return" when I ported the Vala previewer, which ran the code which was only supposed to run if a window was already opened. This then immediately destroyed the just created and shown window, leaving just a ghost window open :ghost:. Kinda impressed Gtk still handled everything fine seemingly, except closing the window again. 
What is a bit strange though is that it doesn't even log a warning until you try to close the window.

Also updated the docstring of the Previewer, the old docstring wasn't accurate anymore.
