### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -3,7 +3,11 @@
   <id>@app_id@</id>
   <launchable type="desktop-id">@app_id@.desktop</launchable>
   <name translatable="no">Workbench</name>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Sonny Piers</developer_name>
+  <developer id="gitlab.com">
+    <name translatable="no">Sonny Piers</name>
+  </developer>
   <update_contact>sonnyp@gnome.org</update_contact>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>

--- a/data/meson.build
+++ b/data/meson.build
@@ -29,14 +29,7 @@ appstream_file = configure_file(
 appstream_cli = find_program('appstreamcli', required: false)
 if appstream_cli.found()
   test('Validate metainfo file', appstream_cli,
-    args: ['validate', '--override=release-time-missing=info', '--no-net', appstream_file]
-  )
-endif
-
-appstreamcli = find_program('appstreamcli', required: false)
-if appstreamcli.found()
-  test('Validate appstream file', appstreamcli,
-    args: ['validate', appstream_file]
+    args: ['validate', '--override=release-time-missing=info', '--no-net', '--explain', appstream_file]
   )
 endif
 


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Remove the second appstreamcli validation
- Improve appstreamcli arguments