### PR TITLE
flatpak: Remove `/app/include` from cleanup

### DIFF
--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -22,7 +22,6 @@
     "--socket=pulseaudio"
   ],
   "cleanup": [
-    "/include",
     "#/lib/pkgconfig",
     "/man",
     "/share/doc",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -22,7 +22,6 @@
     "--socket=pulseaudio"
   ],
   "cleanup": [
-    "/include",
     "#/lib/pkgconfig",
     "/man",
     "/share/doc",


### PR DESCRIPTION
Before this change, Workbench installed via Flatpak was not able to run Vala demos that required Shumate, Libportal or Libspelling because their header files were removed by the cleanup process. The versions of Workbench that are run from Builder or flatpak-vscode can actually compile and execute this demos because they don't do any clean-up, and therefore none of the header files are deleted, which is probably why this issue went unnoticed for quite some time even when porting the affected demos to Vala.

In order to test this changes and compare them with the current version of Workbench, it is necessary to export a bundle and install it, so the cleanup process is actually done.

Closes #885 