### PR TITLE
Don't use deprecated methods

### DIFF
--- a/src/Previewer/External.js
+++ b/src/Previewer/External.js
@@ -31,8 +31,8 @@ export default function External({ output, builder, onWindowChange }) {
     stack.set_visible_child_name("close_window");
     try {
       await dbus_proxy.OpenWindowAsync(
-        output.get_allocated_width(),
-        output.get_allocated_height(),
+        output.get_width(),
+        output.get_height(),
       );
     } catch (err) {
       console.debug(err);

--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -272,8 +272,8 @@ function scopeStylesheet(style, id) {
 
 function screenshot({ widget, path }) {
   const paintable = new Gtk.WidgetPaintable({ widget });
-  const width = widget.get_allocated_width();
-  const height = widget.get_allocated_height();
+  const width = widget.get_width();
+  const height = widget.get_height();
 
   const snapshot = Gtk.Snapshot.new();
   paintable.snapshot(snapshot, width, height);

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -214,7 +214,8 @@ namespace Workbench {
         }
 
         var app_id = GLib.Environment.get_variable("FLATPAK_ID");
-        Resource.load (@"/app/share/$app_id/re.sonny.Workbench.libworkbench.gresource")._register ();
+        var resource = Resource.load (@"/app/share/$app_id/re.sonny.Workbench.libworkbench.gresource");
+        GLib.resources_register (resource);
 
 
         var loop = new MainLoop ();

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -31,8 +31,8 @@ namespace Workbench {
         public bool screenshot (string path) {
             Gtk.Widget widget = this.target;
             var paintable = new Gtk.WidgetPaintable (widget);
-            int width = widget.get_allocated_width ();
-            int height = widget.get_allocated_height ();
+            int width = widget.get_width ();
+            int height = widget.get_height ();
             var snapshot = new Gtk.Snapshot ();
             paintable.snapshot (snapshot, width, height);
             Gsk.RenderNode? node = snapshot.to_node ();

--- a/src/langs/python/python-previewer.py
+++ b/src/langs/python/python-previewer.py
@@ -175,8 +175,8 @@ class Previewer:
     @DBusTemplate.Method()
     def screenshot(self, path: str) -> bool:
         paintable = Gtk.WidgetPaintable(widget=self.target)
-        width = self.target.get_allocated_width()
-        height = self.target.get_allocated_height()
+        width = self.target.get_width()
+        height = self.target.get_height()
         snapshot = Gtk.Snapshot()
         paintable.snapshot(snapshot, width, height)
         node = snapshot.to_node()


### PR DESCRIPTION
This PR utilises the following methods instead of their deprecated counterparts:

- `Gtk.Widget.get_height` instead of `Gtk.Widget.get_allocated_height` 
- `Gtk.Widget.get_width` instead of `Gtk.Widget.get_allocated_width` 
- `GLib.resource_register` instead of `GLib.Resource._register`

Thanks!