### PR TITLE
Removing the install button from Vala in Workbench Extensions

### DIFF
--- a/src/Extensions/Extension.blp
+++ b/src/Extensions/Extension.blp
@@ -33,13 +33,6 @@ template $Extension: ListBoxRow {
       margin-bottom: 14;
       orientation: vertical;
 
-      Button button {
-        label: _("Install");
-        visible: false;
-        halign: start;
-        margin-bottom: 12;
-      }
-
       Label label_hint {
         wrap: true;
         xalign: 0;

--- a/src/Extensions/Extension.js
+++ b/src/Extensions/Extension.js
@@ -57,15 +57,6 @@ export default GObject.registerClass(
     constructor(properties = {}) {
       super(properties);
 
-      if (properties.uri) {
-        this._button.visible = true;
-        this._button.connect("clicked", () => {
-          new Gtk.UriLauncher({ uri: properties.uri })
-            .launch(this.get_root(), null)
-            .catch(console.error);
-        });
-      }
-
       this.bind_property(
         "title",
         this._label_title,

--- a/src/Extensions/Extensions.blp
+++ b/src/Extensions/Extensions.blp
@@ -59,7 +59,7 @@ Adw.Dialog dialog {
 
             $Extension extension_vala {
               title: _("Vala");
-              hint: _("or run the following command");
+              hint: _("Run the following command");
               command: "flatpak install flathub org.freedesktop.Sdk.Extension.vala//23.08";
               uri: "appstream://org.freedesktop.Sdk.Extension.vala";
             }


### PR DESCRIPTION
I have been asked to delete the Install button for Vala in Workbenches extensions due to it having people install a different version of Vala than is needed. Please make sure to look carefull at the changes before merging this to confirm that I did not delete any necessary code by accident.