### PR TITLE
Add base TypeScript view to Workbench

### DIFF
--- a/build-aux/library.js
+++ b/build-aux/library.js
@@ -80,6 +80,9 @@ const demos = [];
     if (demo_dir.get_child("main.py").query_exists(null)) {
       languages.push("python");
     }
+    if (demo_dir.get_child("main.ts").query_exists(null)) {
+      languages.push("typescript");
+    }
     demo.languages = languages;
 
     await copyDemo(

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -6,10 +6,12 @@
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm16"
+    "org.freedesktop.Sdk.Extension.llvm16",
+    "org.freedesktop.Sdk.Extension.node18",
+    "org.freedesktop.Sdk.Extension.typescript"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin",
+    "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin:/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib"
   },
   "command": "workbench",

--- a/src/common.js
+++ b/src/common.js
@@ -115,6 +115,28 @@ export const languages = [
       tabSize: 4,
     },
   },
+  {
+    id: "typescript",
+    name: "TypeScript",
+    panel: "code",
+    extensions: [".ts", ".mts"],
+    types: [],
+    document: null,
+    default_file: "main.ts",
+    index: 4,
+    language_server: [
+      "biome",
+      "lsp-proxy",
+      // src/meson.build installs biome.json there
+      GLib.getenv("FLATPAK_ID")
+        ? `--config-path=${pkg.pkgdatadir}`
+        : `--config-path=src/langs/typescript`,
+    ],
+    formatting_options: {
+      ...formatting_options,
+      tabSize: 2,
+    },
+  },
 ];
 
 export function getLanguage(id) {

--- a/src/langs/typescript/TypeScriptDocument.js
+++ b/src/langs/typescript/TypeScriptDocument.js
@@ -1,0 +1,34 @@
+import { setup } from "./typescript.js";
+
+import Document from "../../Document.js";
+import { applyTextEdits } from "../../lsp/sourceview.js";
+
+export class TypeScriptDocument extends Document {
+  constructor(...args) {
+    super(...args);
+
+    this.lspc = setup({ document: this });
+  }
+
+  async format() {
+    // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_formatting
+    const text_edits = await this.lspc.request("textDocument/formatting", {
+      textDocument: {
+        uri: this.file.get_uri(),
+      },
+      options: {
+        tabSize: 2,
+        insertSpaces: true,
+        trimTrailingWhitespace: true,
+        insertFinalNewline: true,
+        trimFinalNewlines: true,
+      },
+    });
+
+    // Biome doesn't support diff - it just returns one edit
+    // we don't want to loose the cursor position so we use this
+    const state = this.code_view.saveState();
+    applyTextEdits(text_edits, this.buffer);
+    await this.code_view.restoreState(state);
+  }
+}

--- a/src/langs/typescript/biome.json
+++ b/src/langs/typescript/biome.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.3.3/schema.json",
+  "javascript": {
+    "globals": ["workbench"]
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "rules": {
+      "recommended": false,
+      "correctness": {
+        "noUndeclaredVariables": "error",
+        "noUnusedVariables": "warn"
+      }
+    }
+  }
+}

--- a/src/langs/typescript/typescript.js
+++ b/src/langs/typescript/typescript.js
@@ -1,0 +1,32 @@
+import { createLSPClient } from "../../common.js";
+import { getLanguage } from "../../util.js";
+
+export function setup({ document }) {
+  const { file, buffer, code_view } = document;
+
+  const lspc = createLSPClient({
+    lang: getLanguage("typescript"),
+    root_uri: file.get_parent().get_uri(),
+    quiet: true,
+  });
+  lspc.buffer = buffer;
+  lspc.uri = file.get_uri();
+  lspc.connect(
+    "notification::textDocument/publishDiagnostics",
+    (_self, params) => {
+      if (params.uri !== file.get_uri()) {
+        return;
+      }
+      code_view.handleDiagnostics(params.diagnostics);
+    },
+  );
+
+  lspc.start().catch(console.error);
+
+  buffer.connect("modified-changed", () => {
+    if (!buffer.get_modified()) return;
+    lspc.didChange().catch(console.error);
+  });
+
+  return lspc;
+}

--- a/src/window.blp
+++ b/src/window.blp
@@ -187,6 +187,7 @@ Adw.ApplicationWindow window {
                       "Vala",
                       "Rust",
                       "Python",
+                      "TypeScript",
                     ]
                   };
 
@@ -229,6 +230,14 @@ Adw.ApplicationWindow window {
 
                 child: $CodeView code_view_python {
                   language_id: 'python3';
+                };
+              }
+
+              StackPage {
+                name: 'TypeScript';
+
+                child: $CodeView code_view_typescript {
+                  language_id: 'typescript';
                 };
               }
             }

--- a/src/window.js
+++ b/src/window.js
@@ -37,6 +37,7 @@ import { RustDocument } from "./langs/rust/RustDocument.js";
 import { PythonDocument } from "./langs/python/PythonDocument.js";
 import { XmlDocument } from "./langs/xml/XmlDocument.js";
 import { ValaDocument } from "./langs/vala/ValaDocument.js";
+import { TypeScriptDocument } from "./langs/typescript/TypeScriptDocument.js";
 
 import resource from "./window.blp";
 
@@ -103,6 +104,13 @@ export default function Window({ application, session }) {
     session,
   });
   langs.python.document = document_python;
+
+  const document_typescript = new TypeScriptDocument({
+    code_view: builder.get_object("code_view_typescript"),
+    lang: langs.typescript,
+    session,
+  });
+  langs.typescript.document = document_typescript;
 
   const document_blueprint = new BlueprintDocument({
     code_view: builder.get_object("code_view_blueprint"),
@@ -201,13 +209,15 @@ export default function Window({ application, session }) {
     if (panel_code.panel.visible) {
       if (panel_code.language === "JavaScript") {
         documents.push(document_javascript);
-      } else if (panel_code.language === "Rust") {
+      }else if (panel_code.language === "Rust") {
         documents.push(document_rust);
       } else if (panel_code.language === "Python") {
         documents.push(document_python);
       } else if (panel_code.language === "Vala") {
         documents.push(document_vala);
-      }
+      } else if (panel_code.language === "TypeScript") {
+        documents.push(document_typescript);
+      } 
     }
 
     if (builder.get_object("panel_style").visible) {
@@ -332,6 +342,34 @@ export default function Window({ application, session }) {
       } else {
         await previewer.useInternal();
       }
+    } else if (language === "TypeScript") {
+      await previewer.update(true);
+
+      // We have to create a new file each time
+      // because gjs doesn't appear to use etag for module caching
+      // ?foo=Date.now() also does not work as expected
+      // TODO: File a bug
+      const path = buildRuntimePath(`workbench-${Date.now()}`);
+      const file_typescript = Gio.File.new_for_path(path);
+      await file_typescript.replace_contents_async(
+        new GLib.Bytes(text),
+        null,
+        false,
+        Gio.FileCreateFlags.NONE,
+        null,
+      );
+      let exports;
+      try {
+        exports = await import(`file://${file_typescript.get_path()}`);
+      } catch (err) {
+        await previewer.update(true);
+        throw err;
+      } finally {
+        file_typescript
+          .delete_async(GLib.PRIORITY_DEFAULT, null)
+          .catch(console.error);
+      }
+      previewer.setSymbols(exports);
     }
   }
 
@@ -394,6 +432,7 @@ export default function Window({ application, session }) {
 
     await Promise.all([
       document_javascript.load(),
+      document_typescript.load(),
       document_rust.load(),
       document_vala.load(),
       document_python.load(),


### PR DESCRIPTION
This PR is just #933. I had trouble with git and had to create a new PR as Github automatically created a new one.

The issue was related to git not working correctly with "nested" git branch names, i.e. `wip/vixalien/typescript/add-to-view` couldn't coexist well with `wip/vixalien/typescript`, so I named the target branch just `typescript`.