### PR TITLE
Compile TypeScript to JavaScript before executing

### DIFF
--- a/src/PanelCode.js
+++ b/src/PanelCode.js
@@ -1,8 +1,9 @@
 import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 
-import { settings as global_settings, makeDropdownFlat } from "./util.js";
+import { makeDropdownFlat, settings as global_settings } from "./util.js";
 import { setupRustProject } from "./langs/rust/rust.js";
+import { setupTypeScriptProject } from "./langs/typescript/typescript.js";
 
 export default function PanelCode({
   builder,
@@ -55,6 +56,10 @@ export default function PanelCode({
 
     if (panel.language.toLowerCase() === "rust") {
       setupRustProject(file).catch(console.error);
+    }
+
+    if (panel.language.toLowerCase() === "typescript") {
+      setupTypeScriptProject(file).catch(console.error);
     }
   }
   switchLanguage();

--- a/src/langs/rust/rust.js
+++ b/src/langs/rust/rust.js
@@ -1,8 +1,7 @@
 import Gio from "gi://Gio";
-import GLib from "gi://GLib";
 
 import { createLSPClient } from "../../common.js";
-import { getLanguage } from "../../util.js";
+import { getLanguage, copy } from "../../util.js";
 import { isRustEnabled } from "../../Extensions/Extensions.js";
 
 export function setup({ document }) {
@@ -58,23 +57,4 @@ export async function installRustLibraries(destination) {
       Gio.FileCopyFlags.OVERWRITE,
     ),
   ]);
-}
-
-async function copy(filename, source_dir, dest_dir, flags) {
-  const file = source_dir.get_child(filename);
-
-  try {
-    await file.copy_async(
-      dest_dir.get_child(file.get_basename()),
-      flags,
-      GLib.PRIORITY_DEFAULT,
-      null,
-      null,
-      null,
-    );
-  } catch (err) {
-    if (!err.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
-      throw err;
-    }
-  }
 }

--- a/src/langs/typescript/Compiler.js
+++ b/src/langs/typescript/Compiler.js
@@ -1,0 +1,55 @@
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+
+import { buildRuntimePath, copy } from "../../util.js";
+
+export default function Compiler({ session }) {
+  const { file } = session;
+
+  async function compile() {
+    const tsc_launcher = new Gio.SubprocessLauncher();
+    tsc_launcher.set_cwd(file.get_path());
+
+    const tsc = tsc_launcher.spawnv(["tsc", "--project", file.get_path()]);
+    await tsc.wait_async(null);
+
+    const result = tsc.get_successful();
+    tsc_launcher.close();
+    return result;
+  }
+
+  async function run() {
+    // We have to create a new file each time
+    // because gjs doesn't appear to use etag for module caching
+    // ?foo=Date.now() also does not work as expected
+    // TODO: File a bug
+    const path = buildRuntimePath(`workbench-${Date.now()}`);
+    const compiled_dir = Gio.File.new_for_path(path);
+    if (!compiled_dir.query_exists(null)) {
+      await compiled_dir.make_directory_async(GLib.PRIORITY_DEFAULT, null);
+    }
+    await copy(
+      "main.js",
+      file.get_child("compiled_javascript"),
+      compiled_dir,
+      Gio.FileCopyFlags.NONE,
+    );
+    const compiled_file = compiled_dir.get_child("main.js");
+
+    let exports;
+    try {
+      exports = await import(`file://${compiled_file.get_path()}`);
+    } catch (err) {
+      console.error(err);
+      return false;
+    } finally {
+      compiled_file
+        .delete_async(GLib.PRIORITY_DEFAULT, null)
+        .catch(console.error);
+    }
+
+    return exports;
+  }
+
+  return { compile, run };
+}

--- a/src/langs/typescript/template/meson.build
+++ b/src/langs/typescript/template/meson.build
@@ -1,0 +1,3 @@
+install_data(['types/ambient.d.ts', 'types/gi-module.d.ts', 'tsconfig.json'],
+             install_dir : join_paths(pkgdatadir, 'langs/typescript/template'),
+             preserve_path: true)

--- a/src/langs/typescript/template/tsconfig.json
+++ b/src/langs/typescript/template/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    // TODO: should probably be fixed to ES2023, or whatever standard is
+    // currently supported by the latest GJS
+    "target": "ESNext",
+    "outDir": "compiled_javascript",
+    "paths": {
+      "gi://*": ["./types/gi-module.d.ts"]
+    }
+  },
+  "include": ["main.ts", "types/ambient.d.ts", "types/gi-module.d.ts"]
+}

--- a/src/langs/typescript/template/types/ambient.d.ts
+++ b/src/langs/typescript/template/types/ambient.d.ts
@@ -1,0 +1,36 @@
+// additional type declarations for GJS
+
+// additional GJS log utils
+declare function print(...args: any[]): void;
+declare function log(...args: any[]): void;
+
+// GJS pkg global
+declare const pkg: {
+  version: string;
+  name: string;
+};
+
+// old GJS global imports
+// used like: imports.format.printf("...");
+declare module imports {
+  // format import
+  const format: {
+    format(this: String, ...args: any[]): string;
+    printf(fmt: string, ...args: any[]): string;
+    vprintf(fmt: string, args: any[]): string;
+  };
+}
+
+// gettext import
+declare module "gettext" {
+  export function gettext(id: string): string;
+  export function ngettext(
+    singular: string,
+    plural: string,
+    n: number,
+  ): string;
+}
+
+// global workbench object
+// TODO: use correct typings
+declare const workbench: any;

--- a/src/langs/typescript/template/types/gi-module.d.ts
+++ b/src/langs/typescript/template/types/gi-module.d.ts
@@ -1,0 +1,6 @@
+// dummy exports for a module imported with "gi://*"
+// will be replaced later with actual gi-types
+
+declare const module: any;
+
+export default module;

--- a/src/langs/typescript/typescript.js
+++ b/src/langs/typescript/typescript.js
@@ -1,5 +1,7 @@
+import Gio from "gi://Gio";
+
 import { createLSPClient } from "../../common.js";
-import { getLanguage } from "../../util.js";
+import { getLanguage, copy } from "../../util.js";
 import { isTypeScriptEnabled } from "../../Extensions/Extensions.js";
 
 export function setup({ document }) {
@@ -32,4 +34,37 @@ export function setup({ document }) {
   });
 
   return lspc;
+}
+
+const typescript_template_dir = Gio.File.new_for_path(
+  pkg.pkgdatadir,
+).resolve_relative_path("langs/typescript/template");
+
+export async function setupTypeScriptProject(destination) {
+  const types_destination = destination.get_child("types");
+
+  if (!types_destination.query_exists(null)) {
+    types_destination.make_directory_with_parents(null);
+  }
+
+  return Promise.all([
+    copy(
+      "types/ambient.d.ts",
+      typescript_template_dir,
+      types_destination,
+      Gio.FileCopyFlags.NONE,
+    ),
+    copy(
+      "types/gi-module.d.ts",
+      typescript_template_dir,
+      types_destination,
+      Gio.FileCopyFlags.NONE,
+    ),
+    copy(
+      "tsconfig.json",
+      typescript_template_dir,
+      destination,
+      Gio.FileCopyFlags.NONE,
+    ),
+  ]);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ blueprint_compiler = find_program(
 meson.add_install_script('../build-aux/library.js', pkgdatadir)
 
 subdir('langs/rust/template')
+subdir('langs/typescript/template')
 
 configure_file(
   input: 'bin.js',

--- a/src/util.js
+++ b/src/util.js
@@ -88,8 +88,9 @@ export function unstack(fn, onError = console.error) {
 
     if (pending) return;
 
-    if (!latest_promise)
+    if (!latest_promise) {
       latest_promise = fn(...latest_arguments).catch(onError);
+    }
 
     pending = true;
     latest_promise.finally(() => {
@@ -181,6 +182,25 @@ export function removeDirectory(file) {
   // portal.trash_file(file.get_path(), null).catch(console.error);
   try {
     file.trash(null);
+  } catch (err) {
+    if (!err.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
+      throw err;
+    }
+  }
+}
+
+export async function copy(filename, source_dir, dest_dir, flags) {
+  const file = source_dir.get_child(filename);
+
+  try {
+    await file.copy_async(
+      dest_dir.get_child(file.get_basename()),
+      flags,
+      GLib.PRIORITY_DEFAULT,
+      null,
+      null,
+      null,
+    );
   } catch (err) {
     if (!err.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
       throw err;

--- a/src/window.js
+++ b/src/window.js
@@ -15,6 +15,7 @@ import Previewer from "./Previewer/Previewer.js";
 import ValaCompiler from "./langs/vala/Compiler.js";
 import RustCompiler from "./langs/rust/Compiler.js";
 import PythonBuilder from "./langs/python/Builder.js";
+import TypeScriptCompiler from "./langs/typescript/Compiler.js";
 import ThemeSelector from "../troll/src/widgets/ThemeSelector.js";
 import { persistWindowState } from "../troll/src/util.js";
 
@@ -237,6 +238,7 @@ export default function Window({ application, session }) {
   let compiler_vala = null;
   let compiler_rust = null;
   let builder_python = null;
+  let compiler_typescript = null;
 
   async function runCode() {
     const { language } = panel_code;
@@ -288,7 +290,7 @@ export default function Window({ application, session }) {
       return;
     }
 
-    if (language === "JavaScript" || language === "TypeScript") {
+    if (language === "JavaScript") {
       await previewer.update(true);
 
       // We have to create a new file each time
@@ -345,6 +347,20 @@ export default function Window({ application, session }) {
         await previewer.open();
       } else {
         await previewer.useInternal();
+      }
+    } else if (language === "TypeScript") {
+      await previewer.update(true);
+
+      compiler_typescript =
+        compiler_typescript || TypeScriptCompiler({ session, previewer });
+      const success = await compiler_typescript.compile();
+      if (success) {
+        const symbols = await compiler_typescript.run();
+        if (symbols) {
+          previewer.setSymbols(symbols);
+        } else {
+          await previewer.update();
+        }
       }
     }
   }

--- a/src/workbench
+++ b/src/workbench
@@ -8,6 +8,10 @@ export PKG_CONFIG_PATH=/app/lib/pkgconfig/:$PKG_CONFIG_PATH
 source /usr/lib/sdk/rust-stable/enable.sh 2> /dev/null
 source /usr/lib/sdk/vala/enable.sh 2> /dev/null
 source /usr/lib/sdk/llvm16/enable.sh 2> /dev/null
+source /usr/lib/sdk/node18/enable.sh 2> /dev/null
+
+## enabling the typescript extension
+export PATH=$PATH:/usr/lib/sdk/typescript/bin
 
 # TODO: Figure out how to use gcc with mold so we can drop llvm
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang


### PR DESCRIPTION
This basically compiles from TypeScript to JavaScript at runtime when the "Run" button is clicked.

However, there are currently 2 issues worth mentioning:

### 1. Speed

Notice that this is noticeably slow because it's using `tsc`. It could possibly be improved by using `esbuild`, `swc`, `babel` or something similar but then there will be no typechecking when the "Run" button is clicked.

However, I think the above typechecking caveat will not make much sense when we have real-time Intellisense in the editor for TypeScript.

### 2. Sourcemaps

Another consideration is the lack of sourcemap support in GJS. While tsc can generate sourcemaps, this feature is disabled because GJS won't use them. This means that some errors will have the wrong line:column information.

For example:

![image](https://github.com/workbenchdev/Workbench/assets/37999241/c6487292-18a9-4e50-85a0-5c8771f107fc)

Workbench/GJS reports the error is on line number 17 even if it's actually on line number 22 because that's where it ends up after it's compiled to JavaScript (many compilers will eat up unnecessary line breaks even though the minify option is turned off).

I left some TODOs in here where some decisions need to be made and hope to get some feedback