### PR TITLE
Draft: Add typechecking for TypeScript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "blueprint-compiler"]
 	path = blueprint-compiler
 	url = https://gitlab.gnome.org/jwestman/blueprint-compiler.git
+[submodule "src/langs/typescript/template/gi-types"]
+	path = src/langs/typescript/template/gi-types
+	url = https://gitlab.gnome.org/BrainBlasted/gi-typescript-definitions.git
+	branch = nightly

--- a/src/common.js
+++ b/src/common.js
@@ -128,14 +128,7 @@ export const languages = [
     document: null,
     default_file: "main.ts",
     index: 4,
-    language_server: [
-      "biome",
-      "lsp-proxy",
-      // src/meson.build installs biome.json there
-      GLib.getenv("FLATPAK_ID")
-        ? `--config-path=${pkg.pkgdatadir}`
-        : `--config-path=src/langs/typescript`,
-    ],
+    language_server: ["typescript-language-server", "--stdio"],
     formatting_options: {
       ...formatting_options,
       tabSize: 2,

--- a/src/langs/typescript/TypeScriptDocument.js
+++ b/src/langs/typescript/TypeScriptDocument.js
@@ -25,10 +25,6 @@ export class TypeScriptDocument extends Document {
       },
     });
 
-    // Biome doesn't support diff - it just returns one edit
-    // we don't want to loose the cursor position so we use this
-    const state = this.code_view.saveState();
     applyTextEdits(text_edits, this.buffer);
-    await this.code_view.restoreState(state);
   }
 }

--- a/src/langs/typescript/TypeScriptDocument.js
+++ b/src/langs/typescript/TypeScriptDocument.js
@@ -8,8 +8,8 @@ export class TypeScriptDocument extends Document {
     super(...args);
 
     this.lspc = setup({ document: this });
+    this.code_view.lspc = this.lspc;
   }
-
   async format() {
     // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_formatting
     const text_edits = await this.lspc.request("textDocument/formatting", {

--- a/src/langs/typescript/template/meson.build
+++ b/src/langs/typescript/template/meson.build
@@ -1,3 +1,6 @@
-install_data(['types/ambient.d.ts', 'types/gi-module.d.ts', 'tsconfig.json'],
+install_data(['types/ambient.d.ts', 'tsconfig.json'],
              install_dir : join_paths(pkgdatadir, 'langs/typescript/template'),
              preserve_path: true)
+
+install_subdir('gi-types',
+             install_dir : join_paths(pkgdatadir, 'langs/typescript/template'))

--- a/src/langs/typescript/template/tsconfig.json
+++ b/src/langs/typescript/template/tsconfig.json
@@ -6,9 +6,11 @@
     // currently supported by the latest GJS
     "target": "ESNext",
     "outDir": "compiled_javascript",
+    "baseUrl": ".",
     "paths": {
-      "gi://*": ["./types/gi-module.d.ts"]
-    }
+      "*": ["*", "types/*", "gi-types/*"]
+    },
+    "skipLibCheck": true
   },
-  "include": ["main.ts", "types/ambient.d.ts", "types/gi-module.d.ts"]
+  "include": ["main.ts", "types/ambient.d.ts", "gi-types/gi.d.ts"]
 }

--- a/src/langs/typescript/template/tsconfig.json
+++ b/src/langs/typescript/template/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "compiled_javascript",
     "baseUrl": ".",
     "paths": {
-      "*": ["*", "types/*", "gi-types/*"]
+      "*": ["*", "types/*"]
     },
     "skipLibCheck": true
   },

--- a/src/langs/typescript/template/types/gi-module.d.ts
+++ b/src/langs/typescript/template/types/gi-module.d.ts
@@ -1,6 +1,0 @@
-// dummy exports for a module imported with "gi://*"
-// will be replaced later with actual gi-types
-
-declare const module: any;
-
-export default module;

--- a/src/langs/typescript/typescript.js
+++ b/src/langs/typescript/typescript.js
@@ -1,7 +1,7 @@
 import Gio from "gi://Gio";
 
 import { createLSPClient } from "../../common.js";
-import { getLanguage, copy } from "../../util.js";
+import { copy, copyDirectory, ensureDir, getLanguage } from "../../util.js";
 import { isTypeScriptEnabled } from "../../Extensions/Extensions.js";
 
 export function setup({ document }) {
@@ -42,10 +42,10 @@ const typescript_template_dir = Gio.File.new_for_path(
 
 export async function setupTypeScriptProject(destination) {
   const types_destination = destination.get_child("types");
+  ensureDir(types_destination);
 
-  if (!types_destination.query_exists(null)) {
-    types_destination.make_directory_with_parents(null);
-  }
+  const gi_types_destination = destination.get_child("gi-types");
+  ensureDir(gi_types_destination);
 
   return Promise.all([
     copy(
@@ -54,11 +54,9 @@ export async function setupTypeScriptProject(destination) {
       types_destination,
       Gio.FileCopyFlags.NONE,
     ),
-    copy(
-      "types/gi-module.d.ts",
-      typescript_template_dir,
-      types_destination,
-      Gio.FileCopyFlags.NONE,
+    copyDirectory(
+      typescript_template_dir.get_child("gi-types"),
+      gi_types_destination,
     ),
     copy(
       "tsconfig.json",

--- a/src/lsp/LSPClient.js
+++ b/src/lsp/LSPClient.js
@@ -299,7 +299,7 @@ export default class LSPClient {
       },
       position: {
         line: iter_cursor.get_line(),
-        character: iter_cursor.get_line_offset() - 1,
+        character: iter_cursor.get_line_offset(),
       },
     });
 


### PR DESCRIPTION
This is a draft because there are 2 outstanding issues:

### 1. It seems the typechecking really works when you open a previously-saved project

I believe this is because when you open a new project and switch to typescript, the `setupTypeScriptProject` will copy the necessary files and folders (`tsconfig.json`, `types/ambient.d.ts` and `gi-types/*`) to the project. The language server doesn't know that the "project changed" (newly created files) so it won't see the various type augmentations.

The fix could be as easy as to kill and spawn a new language server, but I'm not sure if that would be the right approach.

### 2. The `globalThis.workbench` types aren't there yet

Working on it 🚀 