### PR TITLE
library: Remove usage of Adw.PreferencesWindow

### DIFF
--- a/src/Library/Library.blp
+++ b/src/Library/Library.blp
@@ -1,75 +1,89 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.PreferencesWindow window {
+Adw.Window window {
   hide-on-close: true;
   modal: false;
-  title: _("Workbench — Library");
   default-height: 700;
   default-width: 700;
 
-  Adw.PreferencesPage {
-    Adw.PreferencesGroup {
-      Picture picture_illustration {
-        can-shrink: false;
-        margin-bottom: 32;
-      }
+  Adw.ToolbarView toolbar_view {
 
-      Label {
-        label: _("Learn, Test, Remix");
+    [top]
+    Adw.HeaderBar header_bar {
+      title-widget: Adw.WindowTitle {
+        title: _("Workbench — Library");
+      };
 
-        styles [
-          "title-1"
-        ]
+      [start]
+      ToggleButton button_search {
+        icon-name: "edit-find-symbolic";
       }
     }
 
-    Adw.PreferencesGroup library_uncategorized {}
+    content: Adw.PreferencesPage {
+      Adw.PreferencesGroup {
+        Picture picture_illustration {
+          can-shrink: false;
+          margin-bottom: 32;
+        }
 
-    Adw.PreferencesGroup library_tools {
-      title: _("Tools");
-    }
+        Label {
+          label: _("Learn, Test, Remix");
 
-    Adw.PreferencesGroup library_network {
-      title: _("Network");
-    }
-
-    Adw.PreferencesGroup library_controls {
-      title: _("Controls");
-    }
-
-    Adw.PreferencesGroup library_layout {
-      title: _("Layout");
-    }
-
-    Adw.PreferencesGroup library_feedback {
-      title: _("Feedback");
-    }
-
-    Adw.PreferencesGroup library_navigation {
-      title: _("Navigation");
-    }
-
-    Adw.PreferencesGroup library_user_interface {
-      title: _("User Interface");
-    }
-
-    Adw.PreferencesGroup library_platform {
-      title: _("Platform APIs");
-    }
-
-    Adw.PreferencesGroup {
-      vexpand: true;
-      valign: end;
-
-      Label {
-        label: _('All examples are dedicated to the public domain\nand <b>can be used freely</b> under the terms of <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</a>');
-        use-markup: true;
-
-        styles [
-          "caption"
-        ]
+          styles [
+            "title-1"
+          ]
+        }
       }
-    }
+
+      Adw.PreferencesGroup library_uncategorized {}
+
+      Adw.PreferencesGroup library_tools {
+        title: _("Tools");
+      }
+
+      Adw.PreferencesGroup library_network {
+        title: _("Network");
+      }
+
+      Adw.PreferencesGroup library_controls {
+        title: _("Controls");
+      }
+
+      Adw.PreferencesGroup library_layout {
+        title: _("Layout");
+      }
+
+      Adw.PreferencesGroup library_feedback {
+        title: _("Feedback");
+      }
+
+      Adw.PreferencesGroup library_navigation {
+        title: _("Navigation");
+      }
+
+      Adw.PreferencesGroup library_user_interface {
+        title: _("User Interface");
+      }
+
+      Adw.PreferencesGroup library_platform {
+        title: _("Platform APIs");
+      }
+
+      Adw.PreferencesGroup {
+        vexpand: true;
+        valign: end;
+
+        Label {
+          label: _("All examples are dedicated to the public domain\nand <b>can be used freely</b> under the terms of <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0</a>");
+          use-markup: true;
+
+          styles [
+            "caption"
+          ]
+        }
+      }
+    };
   }
 }

--- a/src/Library/Library.blp
+++ b/src/Library/Library.blp
@@ -4,6 +4,7 @@ using Adw 1;
 Adw.Window window {
   hide-on-close: true;
   modal: false;
+  title: _("Workbench — Library");
   default-height: 700;
   default-width: 700;
 


### PR DESCRIPTION
Initial implementation to move away from Adw.PreferencesWindow for library

**To Do:**

- [x] Move away from `Adw.PreferencesWindow` to alternative
- [ ] Make search work (Shifting to `Adw.Window` breaks search )
- [ ] Library design needs change + Categories and Language filters

Let me know if there are any changes to the latest commit

Screengrabs of the current state:

https://github.com/workbenchdev/Workbench/assets/72352158/78547b64-8f19-4e40-b2c4-782b46e499c1

